### PR TITLE
#11 - Override the setRemoteID and getRemoteID methods

### DIFF
--- a/src/Plugin/Commerce/PaymentGateway/Ecp.php
+++ b/src/Plugin/Commerce/PaymentGateway/Ecp.php
@@ -385,6 +385,7 @@ class Ecp extends OnsiteBase {
     array $payment_details
   ) {
     return [
+      'billingContactInfo' => $this->prepareBillingContactInfo($payment_method),
       'ecp' => [
         'routingNumber' => $payment_details['routing_number'],
         'accountType' => $payment_details['account_type'],


### PR DESCRIPTION
By default Drupal associates the Vaulted Shopper ID with the
specific payment gateway. So, another payment gateway would
not reuse the existing Vaulted Shopper ID and will try to create a new one.
To fix the issue associating the Vaulted Shopper ID with the payment gateway
credentials instead (BlueSnap username) instead of payment gateway entity ID.
That way same remote customer ID can be used for both ACH and HPP payments.