### PR TITLE
Add field for storing a UUID as merchant transaction ID

### DIFF
--- a/src/FieldService.php
+++ b/src/FieldService.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\commerce_bluesnap;
 
+use Drupal\entity\BundleFieldDefinition;
 use Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 
@@ -29,6 +30,24 @@ class FieldService {
     EntityDefinitionUpdateManagerInterface $definition_manager
   ) {
     $this->definitionManager = $definition_manager;
+  }
+
+  /**
+   * Provides the field definition for the merchant transaction ID field.
+   *
+   * @return \Drupal\Core\Field\BaseFieldDefinition
+   *   The field definition.
+   */
+  public static function paymentMerchantTransactionIdFieldDefinition() {
+    return BundleFieldDefinition::create('string')
+      ->setLabel(t('Merchant Transaction ID'))
+      ->setDescription(t('The transaction ID sent to BlueSnap for a payment.'))
+      ->setCardinality(1)
+      ->setReadOnly(TRUE)
+      ->setTranslatable(FALSE)
+      ->setSetting('max_length', 36)
+      ->setSetting('is_ascii', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
   }
 
   /**

--- a/src/Plugin/Commerce/PaymentGateway/Ecp.php
+++ b/src/Plugin/Commerce/PaymentGateway/Ecp.php
@@ -35,9 +35,15 @@ class Ecp extends OnsiteBase {
     $payment_method = $payment->getPaymentMethod();
     $this->assertPaymentMethod($payment_method);
 
+    $remote_id = NULL;
+    $merchant_transaction_id = NULL;
+
     // Check whether the order is a recurring order, if yes perform the
     // recurring transaction.
-    $remote_id = $this->doCreatePaymentForSubscription($payment);
+    list(
+      $remote_id,
+      $merchant_transaction_id
+    ) = $this->doCreatePaymentForSubscription($payment);
 
     // Otherwise we have a regular transaction.
     if (!$remote_id) {
@@ -50,12 +56,14 @@ class Ecp extends OnsiteBase {
       );
       $result = $client->create($data);
       $remote_id = $result->id;
+      $merchant_transaction_id = $data['merchantTransactionId'];
     }
 
     // Mark the payment as pending; it will be marked as completed when we
     // receive the IPN signaling the payment was captured successfully.
     $payment->setState('pending');
     $payment->setRemoteId($remote_id);
+    $payment->set('bluesnap_merchant_transaction_id', $merchant_transaction_id);
     $payment->save();
   }
 
@@ -305,6 +313,7 @@ class Ecp extends OnsiteBase {
     $data = [
       'currency' => $amount->getCurrencyCode(),
       'amount' => $amount->getNumber(),
+      'merchantTransactionId' => $this->uuid->generate(),
       // Authorization is captured by the payment method form.
       'authorizedByShopper' => TRUE,
       'transactionMetadata' => [

--- a/src/Plugin/Commerce/PaymentType/Card.php
+++ b/src/Plugin/Commerce/PaymentType/Card.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\commerce_bluesnap\Plugin\Commerce\PaymentType;
+
+/**
+ * Provides the payment type for Card transactions.
+ *
+ * @CommercePaymentType(
+ *   id = "bluesnap_card",
+ *   label = @Translation("Card"),
+ *   workflow = "payment_default",
+ * )
+ */
+class Card extends PaymentTypeBase {}

--- a/src/Plugin/Commerce/PaymentType/Ecp.php
+++ b/src/Plugin/Commerce/PaymentType/Ecp.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\commerce_bluesnap\Plugin\Commerce\PaymentType;
 
-use Drupal\commerce_payment\Plugin\Commerce\PaymentType\PaymentTypeBase;
-
 /**
  * Provides the payment type for ACH/ECP transactions.
  *
@@ -13,13 +11,4 @@ use Drupal\commerce_payment\Plugin\Commerce\PaymentType\PaymentTypeBase;
  *   workflow = "payment_bluesnap_ecp",
  * )
  */
-class Ecp extends PaymentTypeBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function buildFieldDefinitions() {
-    return [];
-  }
-
-}
+class Ecp extends PaymentTypeBase {}

--- a/src/Plugin/Commerce/PaymentType/PaymentTypeBase.php
+++ b/src/Plugin/Commerce/PaymentType/PaymentTypeBase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\commerce_bluesnap\Plugin\Commerce\PaymentType;
+
+use Drupal\commerce_bluesnap\FieldService;
+use Drupal\commerce_payment\Plugin\Commerce\PaymentType\PaymentTypeBase as Base;
+
+/**
+ * Provides the base payment type class for BlueSnap payment types.
+ */
+class PaymentTypeBase extends Base {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildFieldDefinitions() {
+    return [
+      'bluesnap_merchant_transaction_id' => FieldService::paymentMerchantTransactionIdFieldDefinition(),
+    ];
+  }
+
+}


### PR DESCRIPTION
https://www.drupal.org/project/commerce_bluesnap/issues/3061971

Problem is that the payment ID in Drupal is only generated after we have triggered a successful transaction in BlueSnap and there is no API to update the BlueSnap transaction later.

This approach creates a UUID, sends it with the transaction to BlueSnap, and if the transaction is successful it stores it in the payment in a field.